### PR TITLE
username 중복 현상 에러 해결

### DIFF
--- a/src/main/java/com/example/thebestmeal_test/domain/User.java
+++ b/src/main/java/com/example/thebestmeal_test/domain/User.java
@@ -23,6 +23,9 @@ public class User extends Timestamped {
     @Column(nullable = false)
     private String username;
 
+    @Column(nullable = true)
+    private String nickname;
+
     @Column(nullable = false)
     private String password;
 
@@ -63,8 +66,9 @@ public class User extends Timestamped {
         this.profilePhoto = "/images/profile_pic.jpg";
     }
 
-    public User(String username, String password, String email, UserRole role,Long kakaoId) {
+    public User(String nickname, String username, String password, String email, UserRole role, Long kakaoId) {
         this.username = username;
+        this.nickname = nickname;
         this.password = password;
         this.email = email;
         this.role = role;

--- a/src/main/java/com/example/thebestmeal_test/dto/KakaoJwtResponse.java
+++ b/src/main/java/com/example/thebestmeal_test/dto/KakaoJwtResponse.java
@@ -1,0 +1,15 @@
+package com.example.thebestmeal_test.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@RequiredArgsConstructor
+@Getter
+
+public class KakaoJwtResponse {
+    private final String token;
+    private final String username;
+    private final String nickname;
+
+}

--- a/src/main/java/com/example/thebestmeal_test/service/UserService.java
+++ b/src/main/java/com/example/thebestmeal_test/service/UserService.java
@@ -82,9 +82,9 @@ public class UserService {
         String nickname = userInfo.getNickname();
         String email = userInfo.getEmail();
 
-        // 우리 DB 에서 회원 Id 와 패스워드
-        // 회원 Id = 카카오 nickname
-        String username = nickname;
+        // username 을 nickname 이 아닌 고유값 KakaoId 로 지정
+        String username = Long.toString(kakaoId);
+
         // 패스워드 = 카카오 Id + ADMIN TOKEN
         String password = kakaoId + ADMIN_TOKEN;
 
@@ -98,8 +98,8 @@ public class UserService {
             String encodedPassword = passwordEncoder.encode(password);
             // ROLE = 사용자
             UserRole role = UserRole.USER;
-
-            kakaoUser = new User(nickname, encodedPassword, email, role, kakaoId);
+            kakaoUser = new User(nickname, username, encodedPassword, email, role, kakaoId);
+//            kakaoUser = new User(nickname, encodedPassword, email, role, kakaoId);
             userRepository.save(kakaoUser);
         }
 
@@ -107,9 +107,10 @@ public class UserService {
         Authentication authentication = authenticationManager.authenticate(kakaoUsernamePassword);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
+        //nickname 추가한 KakaoJwtResponse Dto 사용
         final UserDetails userDetails = userDetailsService.loadUserByUsername(username);
         final String token = jwtTokenUtil.generateToken(userDetails);
-        return ResponseEntity.ok(new JwtResponse(token, userDetails.getUsername()));
+        return ResponseEntity.ok(new KakaoJwtResponse(token, userDetails.getUsername(), nickname));
 
     }
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -68,6 +68,7 @@
                 $("#mypage").css("display", "");
                 $("#login").css("display", "none");
                 $("#username").html(localStorage.getItem("username"));
+                $("#nickname").html(localStorage.getItem("nickname"));
 
             } else {
                 //토큰이 없으면 로그아웃된 화면
@@ -75,6 +76,14 @@
                 $("#logout").css("display", "none");
                 $("#mypage").css("display", "none");
             }
+
+            //(카카오 로그인) 유무에 따라 OO님 입력값 변경. 카카오: nickname / 일반: username
+            if (localStorage.getItem("nickname")) {
+                $("#welcomename").html(localStorage.getItem("nickname"));
+            }  else {
+                $("#welcomename").html(localStorage.getItem("username"));
+            }
+
             $.ajax({
                 type: "GET",
                 url: "/liked",
@@ -141,6 +150,11 @@
                 //로그아웃
                 localStorage.removeItem("token");
                 localStorage.removeItem("username");
+                localStorage.removeItem("nickname");
+                Object.keys(localStorage)
+                    .filter(key => key.startsWith('kakao_'))
+                    .forEach(key => localStorage.removeItem(key));
+                // Object.keys(localStorage).filter(key => localStorage.getItem(key).startsWith('kakao_')).forEach(key => localStorage.removeItem(key));
                 location.href = '/';
             });
 
@@ -148,6 +162,7 @@
             $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
                 if (localStorage.getItem('token')) {
                     jqXHR.setRequestHeader('Authorization', 'Bearer ' + localStorage.getItem('token'));
+                    // jqXHR.setRequestHeader('Authorization', 'Bearer ' + localStorage.getItem('token'));
                 }
             });
         })
@@ -290,6 +305,7 @@
                         success: function (response) {
                             localStorage.setItem("token", response['token']);
                             localStorage.setItem("username", response['username']);
+                            localStorage.setItem("nickname", response['nickname']);
                             location.href = '/';
                         }
                     })
@@ -497,7 +513,8 @@
                 <div class="col-lg-6 col-md-8 mx-auto">
                     <h1 class="fw-light"> 오늘 뭐 먹지 ? </h1>
                     <p class="lead text-muted">간단한 질문에 답하고, 오늘의 식사를 추천 받아 보세요!</p>
-                    <p class="lead text-muted" id="userMessege"><span id="username"></span> 님 환영합니다!</p>
+                    <p class="lead text-muted" id="userMessege"><span id="welcomename"></span> 님 환영합니다!</p>
+<!--                    <p class="lead text-muted" id="userMessege"><span id="username"></span> 님 환영합니다!</p>-->
                     <div>
 <!--                        <button type="button" class="main-button" data-bs-toggle="modal"-->
 <!--                                data-bs-target="#SignupPlzModal"-->

--- a/src/main/resources/static/js/mypage.js
+++ b/src/main/resources/static/js/mypage.js
@@ -14,6 +14,12 @@ $(document).ready(function () {
         //로그아웃
         localStorage.removeItem("token");
         localStorage.removeItem("username");
+        localStorage.removeItem("nickname");
+        Object.keys(localStorage)
+            .filter(key => key.startsWith('kakao_'))
+            .forEach(key => localStorage.removeItem(key));
+        // Object.keys(localStorage).filter(key => localStorage.getItem(key).startsWith('kakao_')).forEach(key => localStorage.removeItem(key));
+
         location.href = '/';
     });
     //마이페이지 처음 출력 내가 추천받은 음식

--- a/src/main/resources/static/js/posting.js
+++ b/src/main/resources/static/js/posting.js
@@ -16,6 +16,12 @@ $(document).ready(function () {
             //로그아웃
             localStorage.removeItem("token");
             localStorage.removeItem("username");
+            localStorage.removeItem("nickname");
+            Object.keys(localStorage)
+                .filter(key => key.startsWith('kakao_'))
+                .forEach(key => localStorage.removeItem(key));
+            //삭제가 안된다.
+            // Object.keys(localStorage).filter(key => localStorage.getItem(key).startsWith('kakao_')).forEach(key => localStorage.removeItem(key));
             location.href = '/';
         });
     })

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -46,6 +46,7 @@
                 success: function (response) {
                     localStorage.setItem("token", response['token']);
                     localStorage.setItem("username", response['username']);
+                    localStorage.setItem("nickname", response['nickname']);
                     location.href = '/';
                 }
             })
@@ -63,6 +64,7 @@
                         success: function (response) {
                             localStorage.setItem("token", response['token']);
                             localStorage.setItem("username", response['username']);
+                            localStorage.setItem("nickname", response['nickname']);
                             location.href = '/';
                         }
                     })

--- a/src/main/resources/static/signup.html
+++ b/src/main/resources/static/signup.html
@@ -171,6 +171,7 @@
                         success: function (response) {
                             localStorage.setItem("token", response['token']);
                             localStorage.setItem("username", response['username']);
+                            localStorage.setItem("nickname", response['nickname']);
                             location.href = '/';
                         }
                     })


### PR DESCRIPTION
중복 현상 에러 해결했습니다. 코드 보시고 피드백 주세요! @projectjjj 민님 코드가 더 간결하면 민님 코드로 진행해주시면 됩니당 :) 

Entity 변경점 

-(카카오 로그인 전용) nickname 칼럼 추가. UserApi 의 닉네임이 들어갑니다. 
-기존에는  카카오 로그인 시, 닉네임이 username 칼럼에 들어갔습니다. 
이럴 경우, 동명이인 가입시 unique 값이 되지 않는 에러가 있습니다. 
그래서 KakaoAuth2에서 String username 에 LongId 를 문자열로 변환해서 넣어줍니다. 
회원 가입시에 영문과 숫자 혼합하여 10자 이기 때문에, 일반 가입과 중복 가능성 없습니다. 
 
메인 화면 변경점 
-카카오 로그인은 nickname 이, 일반 회원 가입은 username이 oo 님 환영합니다 값에 들어갑니다. 

LocalStorage 관련 
-LoginStorage 에 nickname을  추가하였습니다.
-Kakao_ 토큰을 따로 삭제해주었습니다. 
